### PR TITLE
Dispatcher Implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { default as Dispatcher } from './modules/Dispatcher';
+export { default as Dispatcher, DispatchPriority } from './modules/Dispatcher';

--- a/modules/Dispatcher.js
+++ b/modules/Dispatcher.js
@@ -1,0 +1,43 @@
+import Heap from './Heap';
+
+export const DispatchPriority = {
+  Persistence: 0,
+  Presentation: 1,
+};
+
+export default class Dispatcher {
+  constructor() {
+    this.listeners = new Heap((a, b) => a.priority > b.priority ? -1 : 1);
+    this.isDispatching = false;
+  }
+
+  dispatch(action) {
+    if (this.isDispatching) {
+      throw new Error('Cannot dispatch in the middle of dispatch');
+    }
+
+    this.isDispatching = true;
+
+    for (let index = 0; index < this.listeners.length; index++) {
+      const listener = this.listeners.get(index);
+
+      try {
+        listener.receive(action);
+      } catch (error) {
+        console.error(listener, error);
+      }
+    }
+
+    this.isDispatching = false;
+  }
+
+  register(listener) {
+    if (!this.listeners.includes(listener)) {
+      this.listeners.insert(listener);
+    }
+  }
+
+  unregister(listener) {
+    this.listeners.delete(listener);
+  }
+}

--- a/modules/Heap.js
+++ b/modules/Heap.js
@@ -1,0 +1,67 @@
+export default class Heap {
+  constructor(comparator = defaultComparator) {
+    this.comparator = comparator;
+    this.items = [];
+  }
+
+  get length() {
+    return this.items.length;
+  }
+
+  get(index) {
+    return this.items[index];
+  }
+
+  insert(item) {
+    const index = this.items.length;
+    this.items.unshift(item);
+    siftDown(this.items, 0, index, this.comparator);
+  }
+
+  includes(item) {
+    return this.items.includes(item);
+  }
+
+  delete(item) {
+    const index = this.items.indexOf(item);
+
+    if (index > -1) {
+      this.items.splice(index, 1);
+    }
+  }
+}
+
+function defaultComparator(a, b) {
+  return a - b;
+}
+
+function siftDown(array, start, end, compare) {
+	let root = start;
+
+	while (root * 2 + 1 <= end) {
+		const lChild = root * 2 + 1;
+		const rChild = lChild + 1;
+		let current = root;
+
+		if (compare(array[current], array[lChild]) < 0) {
+			current = lChild;
+		}
+
+		if (rChild <= end && compare(array[current], array[rChild]) < 0) {
+			current = rChild;
+		}
+
+		if (current === root) {
+			return;
+		}
+
+		swap(array, root, current);
+		root = current;
+	}
+}
+
+function swap(array, indexA, indexB) {
+  const temp = array[indexA];
+  array[indexA] = array[indexB];
+  array[indexB] = temp;
+}

--- a/modules/__tests__/Dispatcher-test.js
+++ b/modules/__tests__/Dispatcher-test.js
@@ -1,0 +1,89 @@
+import Dispatcher from '../Dispatcher';
+
+describe('Dispatcher', () => {
+  it('should execute listeners', () => {
+    const dispatcher = new Dispatcher();
+    const listenerA = { receive: jest.fn() };
+    const listenerB = { receive: jest.fn() };
+    const payload = { name: 'Liza' };
+
+    dispatcher.register(listenerA);
+    dispatcher.register(listenerB);
+    dispatcher.dispatch(payload);
+
+    expect(listenerA.receive).toHaveBeenCalledWith(payload);
+    expect(listenerB.receive).toHaveBeenCalledWith(payload);
+  });
+
+  it('should execute listeners in order of their priority', () => {
+    const dispatcher = new Dispatcher();
+    const history = [];
+    const listenerA = { receive: jest.fn(() => history.push(0)), priority: 0 };
+    const listenerB = { receive: jest.fn(() => history.push(2)), priority: 2 };
+    const listenerC = { receive: jest.fn(() => history.push(1)), priority: 1 };
+    const payload = { name: 'Liza' };
+
+    dispatcher.register(listenerA);
+    dispatcher.register(listenerB);
+    dispatcher.register(listenerC);
+    dispatcher.dispatch(payload);
+
+    expect(history).toEqual([0, 1, 2]);
+  });
+
+  it('should not register a listener twice', () => {
+    const dispatcher = new Dispatcher();
+    const listener = { receive: jest.fn() };
+    const payload = { name: 'Liza' };
+
+    dispatcher.register(listener);
+    dispatcher.register(listener);
+    dispatcher.dispatch(payload);
+
+    expect(listener.receive).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw on nested dispatch', () => {
+    const dispatcher = new Dispatcher();
+    const error = new Error('Cannot dispatch in the middle of dispatch');
+    const listener = { receive: jest.fn(() => dispatcher.dispatch({})) };
+    const payload = { name: 'Liza' };
+
+    spyOn(console, 'error');
+    dispatcher.register(listener);
+    dispatcher.dispatch(payload)
+
+    expect(console.error).toHaveBeenCalledWith(listener, error);
+  });
+
+  it('should not stop dispatch on failure', () => {
+    const dispatcher = new Dispatcher();
+    const error = new Error('Oops');
+    const listenerA = { receive: jest.fn(() => { throw error; }) };
+    const listenerB = { receive: jest.fn() };
+    const payload = { name: 'Liza' };
+
+    spyOn(console, 'error');
+    dispatcher.register(listenerA);
+    dispatcher.register(listenerB);
+    dispatcher.dispatch(payload);
+
+    expect(console.error).toHaveBeenCalledWith(listenerA, error);
+    expect(listenerB.receive).toHaveBeenCalledWith(payload);
+  });
+
+  it('should unregister listeners', () => {
+    const dispatcher = new Dispatcher();
+    const listenerA = { receive: jest.fn() };
+    const listenerB = { receive: jest.fn() };
+    const payload = { name: 'Liza' };
+
+    dispatcher.register(listenerA);
+    dispatcher.register(listenerB);
+    dispatcher.unregister(listenerA);
+    dispatcher.dispatch(payload);
+
+    expect(listenerA.receive).not.toHaveBeenCalled();
+    expect(listenerB.receive).toHaveBeenCalledWith(payload);
+  });
+});

--- a/modules/__tests__/Heap-test.js
+++ b/modules/__tests__/Heap-test.js
@@ -1,0 +1,72 @@
+import Heap from '../Heap';
+
+describe('Heap', () => {
+  it('should add items to heap', () => {
+    const heap = new Heap();
+
+    heap.insert(10);
+    heap.insert(8);
+    heap.insert(3);
+    heap.insert(13);
+    heap.insert(1);
+    heap.insert(0);
+
+    expect(heap.items).toEqual([13, 10, 8, 0, 3, 1]);
+  });
+
+  it('should use custom comparator', () => {
+    const heap = new Heap((a, b) => a > b ? -1 : 1);
+
+    heap.insert(0);
+    heap.insert(1);
+    heap.insert(2);
+    heap.insert(3);
+    heap.insert(4);
+    heap.insert(4);
+    heap.insert(4);
+    heap.insert(4);
+    heap.insert(2);
+    heap.insert(2);
+
+    expect(heap.items).toEqual([0, 1, 2, 2, 2, 3, 4, 4, 4, 4]);
+  });
+
+  it('should check an item existense', () => {
+    const heap = new Heap();
+    const value = 13;
+
+    heap.insert(value);
+
+    expect(heap.includes(value)).toBe(true);
+  });
+
+  it('should be possible to iterate over items', () => {
+    const heap = new Heap();
+
+    heap.insert(1);
+    heap.insert(2);
+
+    expect(heap.get(0)).toBe(2);
+    expect(heap.get(1)).toBe(1);
+  });
+
+  it('should delete an item', () => {
+    const heap = new Heap();
+    const value = 13;
+
+    heap.insert(value);
+    heap.delete(value);
+
+    expect(heap.includes(value)).toBe(false);
+  });
+
+  it('should not modify items on false deletion', () => {
+    const heap = new Heap();
+    const value = 13;
+
+    spyOn(heap.items, 'splice');
+    heap.delete(value);
+
+    expect(heap.items.splice).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Rationale

Dispatcher is the core element of Flux pattern. Having it implemented first helps to build the other required elements.

Proposed dispatcher has a known API:

```typescript
class Dispatcher {
  dispatch(action: Action): void;
  register(listener: Listener): void;
  unregister(listener: Listener): void;
}
```

Dispatcher requires listeners to satisfy next interface:

```typescript
interface Listener {
  priority: number;
  receive(action: Action): void;
}
```

This prevents the usage of anonymous functions (that break stacktraces) and makes unneeded the "subscription" entity (something that should be saved in favor to unregister a listener later). The receiver function is called with its context which prevents unnecessary bindings and wrappers.

There is a priority levels enum implemented along with the dispatcher (export name is debatable, I'm opened to suggestions):

```typescript
const DispatchPriority = {
  Persistence: 0,
  Presentation: 1,
};
```

So far it only have two priorities that will satisfy the main requirement for **stores** (`DispatchPriority.Persistence`) and **containers** (`DispatchPriority.Presentation`).

Once dispatched action is sent to all listeners. Containers usually depend on stores which means stores should done their updated before containers received the action. To ensure the order, Facebook's implementation [has](http://facebook.github.io/flux/docs/in-depth-overview.html#what-about-that-dispatcher) a method `waitFor()` which was always controversial. In fact, since containers are initialized later than stores, it may not have sense to even think about such edge case just because a container's listener is registered later than store's one. However, there can be a case, where a store can be instantiated later than the container which uses it:

```javascript
getStores(props, context) {
  const things = props.flag ? NewThingsListStore.of(Dispatcher) : LegacyListStore.of(Dispatcher);
  return [things];
}
```

In the example above, by switching the flag in props, we can instantiate some of stores later comparing to the container which affects the order of listeners (if there is no regulation). That is why the dispatcher executes listeners in order of their priority defined by the enum. The registration process is covered by [Binary Heap](https://en.wikipedia.org/wiki/Binary_heap) (the structure is implemented along with the dispatcher).

Dispatcher executes a listener in `try..catch` block to prevent failures that would stop all subsequent executions and logs the exceptions with their listeners. 

## Changes

 * [x] Implemented fully functional dispatcher with priorities enum exposed to the public API

## Testing

Both dispatcher and heap data structure are 100% covered with unit tests.