### PR TITLE
Store Implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 export { default as Dispatcher, DispatchPriority } from './modules/Dispatcher';
+export { default as Store, StoreRegistry } from './modules/Store';

--- a/modules/Store.js
+++ b/modules/Store.js
@@ -1,0 +1,37 @@
+import { DispatchPriority } from './Dispatcher';
+
+export const StoreRegistry = new Map();
+
+export default class Store {
+  static of(dispatcher) {
+    if (StoreRegistry.has(this)) {
+      return StoreRegistry.get(this);
+    }
+
+    const instance = new this();
+    dispatcher.register(instance);
+    StoreRegistry.set(this, instance);
+    return instance;
+  }
+
+  constructor() {
+    this.priority = DispatchPriority.Persistence;
+    this.state = this.getInitialState();
+  }
+
+  receive(action) {
+    this.state = this.reduce(this.state, action);
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  getInitialState() {
+    throw new Error('Abstract method getInitialState() is not implemented');
+  }
+
+  reduce() {
+    throw new Error('Abstract method reduce() is not implemented');
+  }
+}

--- a/modules/__mocks__/Dispatcher.js
+++ b/modules/__mocks__/Dispatcher.js
@@ -1,0 +1,10 @@
+export const DispatchPriority = {
+  Persistence: 0,
+  Presentation: 1,
+};
+
+export default function Dispatcher() {
+  this.dispatch = jest.fn();
+  this.register = jest.fn();
+  this.unregister = jest.fn();
+}

--- a/modules/__tests__/Store-test.js
+++ b/modules/__tests__/Store-test.js
@@ -1,0 +1,59 @@
+jest.mock('../Dispatcher');
+
+import Dispatcher from '../Dispatcher';
+import Store, { StoreRegistry } from '../Store';
+
+describe('Store', () => {
+  const InitialState = [];
+
+  class DefaultStore extends Store {
+    getInitialState() {
+      return InitialState;
+    }
+  }
+
+  it('should have initial state', () => {
+    const store = new DefaultStore();
+
+    expect(store.state).toBe(InitialState);
+    expect(store.getState()).toBe(InitialState);
+  });
+
+  it('should register a listener', () => {
+    const dispatcher = new Dispatcher();
+    const store = DefaultStore.of(dispatcher);
+
+    expect(dispatcher.register).toHaveBeenCalledWith(store);
+  });
+
+  it('should be a singleton', () => {
+    class CustomStore extends DefaultStore { }
+    const dispatcher = new Dispatcher();
+    const storeA = CustomStore.of(dispatcher);
+    const storeB = CustomStore.of(dispatcher);
+
+    expect(storeA).toBe(storeB);
+    expect(StoreRegistry.get(CustomStore)).toBe(storeA);
+  });
+
+  it('should update state', () => {
+    class CustomStore extends DefaultStore {
+      reduce(state, action) {
+        return state.concat(action);
+      }
+    }
+    const store = new CustomStore();
+
+    store.receive(1);
+
+    expect(store.getState()).toEqual([1]);
+  });
+
+  it('should provide abstract methods', () => {
+    class EmptyStore extends Store { }
+    class NotFullStore extends Store { getInitialState() {} }
+
+    expect(() => new EmptyStore()).toThrow('Abstract method getInitialState() is not implemented');
+    expect(() => new NotFullStore().reduce()).toThrow('Abstract method reduce() is not implemented');
+  });
+});


### PR DESCRIPTION
## Rationale

Store as a data cache is the most important element in Flux's data flow. It listens to Dispatcher and updates its internal state based on custom `reduce()` function.

In the same way, as in the original Flux, custom stores should extend base Store class and override `getInitialState` and `reduce()` methods:

```typescript
class CustomStore extends Store {
  getInitialState() {
    return ...;
  }

  reduce(state, action) {
    return ...;
  }
}
```

Presented Store implementation satisfy `Listener` interface that was introduced in #2. It uses `Persistence` priority level to be updated before any other listeners. This solves the issue with the need of `waitFor()` method: dispatcher ensures that stores are updated at the very beginning.

Store base class is implemented with [Singleton pattern](https://en.wikipedia.org/wiki/Singleton_pattern) in mind. This differs from the original Flux implementation where it's common to just instantiate _a single instance_ as a default export.

```typescript
const dispatcher = new Dispatcher();
const store = CustomStore.of(dispatcher);
```

Factory method `of()` registers store in the dispatcher, so there is no need for a store to have a reference to the dispatcher. Also, it adds an instance to the registry, which ensures the pattern and provides a future-proof way to get the data from all stores. This will be helpful when we'll consider having some kind of dev tools.

## Changes

 * [x] Implemented fully functional store with instance registry exposed to the public API

## Testing

Store base class is 100% covered with unit tests.