### PR TITLE
Container Implementation

### DIFF
--- a/modules/Container.js
+++ b/modules/Container.js
@@ -1,0 +1,47 @@
+import { Component } from 'react';
+import { DispatchPriority } from './Dispatcher';
+import { DispatcherProperty } from './Provider';
+
+export default class Container extends Component {
+  static from(render, calculateState) {
+    return class extends Container {
+      calculateState(state, props, context) {
+        return calculateState(state, props, context);
+      }
+
+      render() {
+        return render(this.state, this.props);
+      }
+    }
+  }
+
+  static get contextTypes() {
+    return { dispatcher: DispatcherProperty };
+  }
+
+  constructor(props, context) {
+    super(props, context);
+    this.priority = DispatchPriority.Presentation;
+    this.state = this.calculateState(null, props, context);
+  }
+
+  calculateState() {
+    throw new Error('Abstract method calculateState() is not implemented');
+  }
+
+  receive() {
+    this.setState(state => this.calculateState(state, this.props, this.context));
+  }
+
+  componentDidMount() {
+    this.context.dispatcher.register(this);
+  }
+
+  componentWillReceiveProps(nextProps, nextContext) {
+    this.setState(state => this.calculateState(state, nextProps, nextContext));
+  }
+
+  componentWillUnmount() {
+    this.context.dispatcher.unregister(this);
+  }
+}

--- a/modules/Provider.js
+++ b/modules/Provider.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import Dispatcher from './Dispatcher';
+
+export function DispatcherProperty(props, propName, componentName) {
+  if (!(props[propName] instanceof Dispatcher)) {
+    throw new Error(`Invalid ${propName} supplied to ${componentName}`);
+  }
+}
+
+export default class Provider extends Component {
+  static get childContextTypes() {
+    return { dispatcher: DispatcherProperty };
+  }
+
+  static get propTypes() {
+    return { dispatcher: DispatcherProperty };
+  }
+
+  getChildContext() {
+    return { dispatcher: this.props.dispatcher };
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/modules/__tests__/Container-test.js
+++ b/modules/__tests__/Container-test.js
@@ -1,0 +1,105 @@
+jest.mock('../Dispatcher');
+
+import Container from '../Container';
+import Dispatcher from '../Dispatcher';
+import { DispatcherProperty } from '../Provider';
+
+describe('Container', () => {
+  const calculateState = jest.fn();
+  const render = jest.fn();
+  const setState = jest.fn();
+
+  class CustomContainer extends Container {
+    get calculateState() { return calculateState; }
+    get render() { return render; }
+    get setState() { return setState; }
+  }
+
+  it('should expect dispatcher in context', () => {
+    expect(Container.contextTypes.dispatcher)
+      .toBe(DispatcherProperty);
+  });
+
+  it('should throw on abstract method', () => {
+    expect(() => new Container())
+      .toThrow('Abstract method calculateState() is not implemented');
+  });
+
+  it('should calculate initial state', () => {
+    const props = {};
+    const context = {};
+    const container = new CustomContainer(props, context);
+
+    expect(container.calculateState)
+      .toHaveBeenCalledWith(null, props, context);
+  });
+
+  it('should register', () => {
+    const dispatcher = new Dispatcher();
+    const container = new CustomContainer(null, { dispatcher });
+
+    container.componentDidMount();
+
+    expect(dispatcher.register)
+      .toHaveBeenCalledWith(container);
+  });
+
+  it('should unregister', () => {
+    const dispatcher = new Dispatcher();
+    const container = new CustomContainer(null, { dispatcher });
+
+    container.componentWillUnmount();
+
+    expect(dispatcher.unregister)
+      .toHaveBeenCalledWith(container);
+  });
+
+  it('should re-calculate state on action', () => {
+    const state = {};
+    const props = {};
+    const context = {};
+    const container = new CustomContainer(props, context);
+
+    setState.mockImplementation(fn => fn(state));
+    container.receive();
+
+    expect(container.calculateState)
+      .toHaveBeenCalledWith(state, props, context);
+  });
+
+  it('should re-calculate state on props change', () => {
+    const state = {};
+    const props = {};
+    const context = {};
+    const nextProps = {};
+    const nextContext = {};
+    const container = new CustomContainer(props, context);
+
+    setState.mockImplementation(fn => fn(state));
+    container.componentWillReceiveProps(nextProps, nextContext);
+
+    expect(container.calculateState)
+      .toHaveBeenCalledWith(state, nextProps, nextContext);
+  });
+
+  it('should provide a shorthand syntax', () => {
+    const state = {};
+    const props = {};
+    const context = {};
+    const plainRender = jest.fn();
+    const plainCalculateState = jest.fn(() => state);
+    const ShorthandContainer = Container.from(plainRender, plainCalculateState);
+    const container = new ShorthandContainer(props, context);
+
+    container.render();
+
+    expect(container instanceof Container)
+      .toBeTruthy();
+
+    expect(plainCalculateState)
+      .toHaveBeenCalledWith(null, props, context);
+
+    expect(plainRender)
+      .toHaveBeenCalledWith(state, props);
+  });
+});

--- a/modules/__tests__/Provider-test.js
+++ b/modules/__tests__/Provider-test.js
@@ -1,0 +1,40 @@
+import Dispatcher from '../Dispatcher';
+import Provider, { DispatcherProperty } from '../Provider';
+
+describe('Provider', () => {
+  it('should expect a dispatcher', () => {
+    const dispatcher = new Dispatcher();
+    const props = { dispatcher };
+    const componentName = 'SomeComponent';
+
+    expect(() => DispatcherProperty(props, 'dispatcher', componentName))
+      .not.toThrow();
+
+    expect(() => DispatcherProperty({}, 'dispatcher', componentName))
+      .toThrow('Invalid dispatcher supplied to SomeComponent');
+  });
+
+  it('should require a dispatcher in props', () => {
+    expect(Provider.propTypes.dispatcher)
+      .toBe(DispatcherProperty);
+  });
+
+  it('should provide a dispatcher throught context', () => {
+    const dispatcher = new Dispatcher();
+    const provider = new Provider({ dispatcher });
+
+    expect(Provider.childContextTypes.dispatcher)
+      .toBe(DispatcherProperty);
+
+    expect(provider.getChildContext().dispatcher)
+      .toBe(dispatcher);
+  });
+
+  it('should render children', () => {
+    const children = {};
+    const provider = new Provider({ children });
+
+    expect(provider.render())
+      .toBe(children);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "rollup": "~0.47.6",
     "rollup-plugin-babel": "~3.0.2"
   },
+  "peerDependencies": {
+    "react": "~16.0.0"
+  },
   "babel": {
     "presets": [
       "es2015"


### PR DESCRIPTION
## Rationale

As we define this project as React-oriented, there should be an official binding provided from the box.

Facebook's Flux implementation provide `Container` object that defines the API and approach that hardly can be explained to a newcomer: static methods, `getStores()` may make zero sense and can be explained only by the internal implementation that is pretty naive and based on decisions that are not applicable to React itself.

Since we already got rid of mechanism like `waitFor()` and defined the dispatcher as a priority queue, there are no reasons we need to mimic the API that Facebook's implementation provides. Instead, we can focus on providing the API that is closer to the ecosystem and idiomatic from JavaScript perspective.

This PR defines `Container` base class that extends `React.Component` and provides a way to bind stores to the view component:

```javascript
import React from 'react';
import { Container } from 'dataloop/react';
import UserList from './UserList.react';
import UserListStore from './UserListStore';

export default class UserListContainer extends Container {
  calculateState() {
    const users = UserListStore.getUsers();
    return { users };
  }

  render() {
    return <UserList users={this.state.users} />;
  }
}
```

So the result can be used as a plain component:

```javascript
ReactDOM.render(<UserListContainer />, ...);
```

The key point: container hides the subscription and lifecycle, while user defines `render()` (as usual) and `calculateState()` that works in the same way: it has no state, it just returns data that is set as `this.state` in the container. In addition, it receives current state, props, and context, in case they can be helpful to figure the next state.

Additionally, there is a way to define a container without writing a class. There is a static method `Container.from()` that receives a render function (functional stateless component) and `calculateState()` function:

```javascript
function calculateState() {
  const users = UserListStore.getUsers();
  return { users };
}

function UserList({ users }) {
  return ...;
}

export default Container.from(UserList, calculateState);
```

Facebook's Flux has a weird way to extract the dispatcher instance from stores that are used by the container. Since we don't save the dispatcher reference in stores, there should be some way to provide it to containers. One of the ways that seem to be common in the community is a provider component:

```javascript
import React from 'react';
import ReactDOM from 'react-dom';
import { Provider } from 'dataloop/react';
import App from './AppRoot';
import Dispatcher from './AppDispatcher';

ReactDOM.render((
  <Provider dispatcher={Dispatcher}>
    <App />
  </Provider>
), ...);
```

Or with a shorthand syntax:

```javascript
ReactDOM.render(<Provider dispatcher={Dispatcher} children={App} />, ...);
```

In this way, the dispatcher is passed through the context and is accessible by all containers with no need to import it in every each container file.

It may be not a perfect solution due to the need to wrap root component. We may provide an example, where the dispatcher instance is added to the context manually as a part of other context definitions. Anyway, if there will be some better solution, we can drop Provider component with the version bump.

As a next step, we need to bundle `Provider` and `Container` in a separate module which will be accessible via `dataloop/react`. In this way, non-React users won't bundle unnecessary things in their projects:

```javascript
import { Dispatcher, Store } from 'dataloop';
import { Container, Provider } from 'dataloop/react';
```

It also allows us to define more bindings besides React if needed.

## Changes

 - [x] Implemented container base class that allows defining React components fueled by stores
 - [x] Implemented helper component `<Provider />` that passes the dispatcher through the context
 - [x] Implemented `DispatcherProperty` type checker that can be used for defining prop and context types

## Testing

Container and Provider classes are 100% covered with unit tests. There are no tests that include React, just checking the contracts React requires.