### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## dataloop v0.1.0
+
+**New Features**:
+
+ * [Dispatcher][dispatcher]'s initial implementation ([#2](https://github.com/PlatinumCoin/dataloop/pull/2))
+ * [Store][store]'s initial implementation ([#3](https://github.com/PlatinumCoin/dataloop/pull/3))
+
+ [dispatcher]: https://platinumcoin.github.io/dataloop/Dispatcher.html
+ [store]: https://platinumcoin.github.io/dataloop/Store.html

--- a/docs/Dispatcher.md
+++ b/docs/Dispatcher.md
@@ -1,0 +1,6 @@
+# Dispatcher
+
+Global message queue which is used for dispatching actions. Once dispatched,
+action is sent to all dispatcher’s listeners. To prevent circular dispatches
+and updates that might cause bugs and performance issues, dispatcher’s
+listeners cannot dispatch new actions.

--- a/docs/Store.md
+++ b/docs/Store.md
@@ -1,0 +1,6 @@
+# Store
+
+Data cache objects. Store can contain a model or collection of models that
+should be a part of domain model. Store may listen to the dispatcher and update
+its state based on dispatched actions. Store should not introduce any setters
+or its data to public API.


### PR DESCRIPTION
## Rationale

It's time to do the initial release.

## Changes

 - [x] CHANGELOG.md created with `v0.1.0` changes
 - [x] Doc pages created for `Dispatcher` and `Store` (with a small description so far)