### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## dataloop v0.1.1
+
+**Bug Fixes**:
+
+ * Fixed [Dispatcher][dispatcher]'s internal priorities mechanism ([#7](https://github.com/PlatinumCoin/dataloop/pull/7))
+
 ## dataloop v0.1.0
 
 **New Features**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataloop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Unidirectional Data Flow Implementation",
   "main": "dataloop.js",
   "module": "dataloop.module.js",


### PR DESCRIPTION
## Rationale

Since we didn't expose `Heap` in public API, we can consider this change as a fix.

## Changes 

 - [x] CHANGELOG.md updated with v0.1.1 changes