### PR TITLE
Asynchronous Dispatch

### DIFF
--- a/modules/AsyncQueue.js
+++ b/modules/AsyncQueue.js
@@ -1,0 +1,26 @@
+export default class AsyncQueue {
+  constructor() {
+    this.values = [];
+    this.resolvers = [];
+  }
+
+  enqueue(value) {
+    if (this.resolvers.length > 0) {
+      const resolve = this.resolvers.shift();
+      resolve({ value, done: false });
+    } else {
+      this.values.push(value);
+    }
+  }
+
+  next() {
+    return new Promise(resolve => {
+      if (this.values.length > 0) {
+        const value = this.values.shift();
+        resolve({ value, done: false });
+      } else {
+        this.resolvers.push(resolve);
+      }
+    });
+  }
+}

--- a/modules/Dispatcher.js
+++ b/modules/Dispatcher.js
@@ -7,6 +7,12 @@ export const DispatchPriority = {
 };
 
 export default class Dispatcher {
+  static create() {
+    const instance = new this();
+    instance.spawn();
+    return instance;
+  }
+
   constructor() {
     this.actions = new AsyncQueue();
     this.listeners = new OrderedSet((a, b) => a.priority < b.priority ? -1 : 1);

--- a/modules/__mocks__/AsyncQueue.js
+++ b/modules/__mocks__/AsyncQueue.js
@@ -1,0 +1,13 @@
+export default function AsyncQueue() {
+  const values = [];
+
+  this.enqueue = jest.fn((value) => {
+    values.push(value);
+  });
+
+  this.next = jest.fn(() => {
+    const value = values.shift();
+    const done = value === undefined;
+    return Promise.resolve({ value, done });
+  });
+}

--- a/modules/__tests__/AsyncQueue-test.js
+++ b/modules/__tests__/AsyncQueue-test.js
@@ -1,0 +1,25 @@
+import AsyncQueue from '../AsyncQueue';
+
+describe('AsyncQueue', () => {
+  it('should enqueue before dequeue', async () => {
+    const queue = new AsyncQueue();
+    queue.enqueue('A');
+    queue.enqueue('B');
+    const values = Promise.all([queue.next(), queue.next()]);
+    expect(await values).toEqual([
+      { value: 'A', done: false },
+      { value: 'B', done: false },
+    ]);
+  });
+
+  it('should dequeue before enqueue', async () => {
+    const queue = new AsyncQueue();
+    const values = Promise.all([queue.next(), queue.next()]);
+    queue.enqueue('A');
+    queue.enqueue('B');
+    expect(await values).toEqual([
+      { value: 'A', done: false },
+      { value: 'B', done: false },
+    ]);
+  });
+});

--- a/modules/__tests__/Dispatcher-test.js
+++ b/modules/__tests__/Dispatcher-test.js
@@ -96,4 +96,12 @@ describe('Dispatcher', async () => {
     expect(listenerA.receive).not.toHaveBeenCalled();
     expect(listenerB.receive).toHaveBeenCalledWith(payload);
   });
+
+  it('should instantiate dispatcher with its lifecycle', () => {
+    jest.spyOn(Dispatcher.prototype, 'spawn');
+    const dispatcher = Dispatcher.create();
+
+    expect(dispatcher).toBeInstanceOf(Dispatcher);
+    expect(dispatcher.spawn).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Rationale

This PR introduces breaking changes to Dispatcher's public API.

One of the things that was bothering [Facebook] Flux users, is the exception "Cannot dispatch in the middle of dispatch". Since `dispatch()` call is synchronous, it makes sense to prevent running infinite blocking loop. Unfortunately, the exception is inconvenient when it appears due to interop with React components lifecycle and render of nested containers that may dispatch an action from cDM.

Another point to consider, is the fact `dispatch()` is synchronous. This means completely blocked thread for notifying all stores and containers, before continuing. While this seems to not actually be a real issue, it still produces cases where GC can really block the thread because of all stores that were updated at once.

For the sake of getting rid of the exception, and taking care of JS event loop, this PR introduces changes that make `dispatch()` method asynchronous, notifying listeners only during [microtasks resolving phase](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/).

Assuming `dispatch()` should become asynchronous means there should be a queue of actions to dispatch at some point of time. I initially tried to keep a promise instance as Dispatcher's own property and dispatch when the promise is resolved. However, it complicates Dispatcher's logic and introduces mutable property that can be messed up during multiple dispatches from different places.

Another strategy was selected: using queue data structure that can resolve next item in asynchronous manner. Structure `AsyncQueue` is basically an [async iterator](http://2ality.com/2016/10/asynchronous-iteration.html) which `next()` method produces Promise of IteratorResult (`{ value, done }`). The logic of `AsyncQueue` is primitive and does not interfere with Dispatcher's logic. Thus, Dispatcher makes use of the queue without blurring the logic or sharing the knowledge.

Method `dispatch()` now simply makes `enqueue()` of the action. It is a single operation which is cheap for the thread. Separate mechanism iterates over async queue and notifies listeners with a new action, one at a time. The order is preserved, each async resolving happens in microtasks resolving phase.

There is a need of iterating over the async queue, since the data structure is pull-based. The logic of iterations looks like this:

```javascript
async iterations() {
  for await (const action of asyncQueue) {
    dispatch(action);
  }
}
```

For the sake of not bloating the library distributive with transpiled version of for..await..of (which needs regenerator runtime) I've implemented iteration as "trampoline". I don't want to put this mechanism to `constructor()` because it's impure, so I've added `spawn()` public method that spins up Dispatcher's dispatch loop. Basically, the instance of Dispatcher, that is used in the app, should be initialized in the entrypoint:

```javascript
// index.js
import Dispatcher from './core/Dispatcher';

Dispatcher.spawn();
```

## Changes

 - [x] Changed behavior of `dispatch()` method to asynchronous and get rid of the exception for nested dispatches
 - [x] Implemented `spawn()` public method to spin up dispatcher's cycle

## Testing

In normal conditions, `spawn()` produces a Promise that doesn't resolve, because of the queue that does not close its iterator. For the sake of testing async dispatch, we still need to wait for dispatch cycle. I've mocked `AsyncQueue` for Dispatcher's tests so it can be _finite_ and `spawn()` actually resolves once all queued actions are dispatched. `AsyncQueue` has its separate tests. Method `spawn()` is tested by its usage in other tests. The test for dispatch exception is replaced with the test of nested dispatches.